### PR TITLE
Fix cross-domain requests skipping ignore rules

### DIFF
--- a/routing/NormaliseMiddleware.php
+++ b/routing/NormaliseMiddleware.php
@@ -1,6 +1,7 @@
 <?php
 namespace BennoThommo\UrlNormaliser\Routing;
 
+use App;
 use BennoThommo\UrlNormaliser\Models\Settings;
 use Config;
 use Closure;
@@ -20,6 +21,11 @@ class NormaliseMiddleware
      */
     public function handle($request, Closure $next)
     {
+        // Always allow backend to be accessed
+        if (App::runningInBackend()) {
+            return $next($request);
+        }
+
         $settings = Settings::instance();
         $urlInfo = parse_url($request->fullUrl());
         $domain = $urlInfo['host'];


### PR DESCRIPTION
Does a more thorough check to see if the user is running in the Backend context. This fixes issues with cross-domain requests, where it failed the `$request->is()` check even if the path was in the ignore list.